### PR TITLE
Remove nils from the token array before join

### DIFF
--- a/lib/flash_cookie_session/middleware.rb
+++ b/lib/flash_cookie_session/middleware.rb
@@ -10,7 +10,7 @@ module FlashCookieSession
         req = Rack::Request.new(env)
         the_session_key = [ @session_key, req.params[@session_key] ].join('=').freeze if req.params[@session_key]
         the_remember_token = [ 'remember_token', req.params['remember_token'] ].join('=').freeze if req.params['remember_token']
-        cookie_with_remember_token_and_session_key = [ the_remember_token, the_session_key ].join(';').freeze
+        cookie_with_remember_token_and_session_key = [ the_remember_token, the_session_key ].compact.join(';').freeze
         env['HTTP_COOKIE'] = cookie_with_remember_token_and_session_key
         env['HTTP_ACCEPT'] = "#{req.params['_http_accept']}".freeze if req.params['_http_accept']
       end


### PR DESCRIPTION
the_remember_token sometimes is nil and then Rails 3.2 throws an exception.
