### PR TITLE
Fix cookies change when download swf files

### DIFF
--- a/lib/flash_cookie_session/middleware.rb
+++ b/lib/flash_cookie_session/middleware.rb
@@ -6,7 +6,8 @@ module FlashCookieSession
     end
 
     def call(env)
-      if env['HTTP_USER_AGENT'] =~ /^(Adobe|Shockwave) Flash/ or env['HTTP_REFERER'] =~ /.swf/
+      # if env['HTTP_USER_AGENT'] =~ /^(Adobe|Shockwave) Flash/ or env['HTTP_REFERER'] =~ /.swf/
+      if env['HTTP_USER_AGENT'] =~ /^(Adobe|Shockwave) Flash/
         req = Rack::Request.new(env)
         the_session_key = [ @session_key, req.params[@session_key] ].join('=').freeze if req.params[@session_key]
 


### PR DESCRIPTION
when the browser download the swf from our server

``` ruby
if env['HTTP_USER_AGENT'] =~ /^(Adobe|Shockwave) Flash/ or env['HTTP_REFERER'] =~ /.swf/
  # ...
end
```

this code will be executed, and then the cookie will be changed. So if the browser senf an ajax request, it will be fail with the error `Can't verify CSRF token authenticity`. And I have to sign in again!

So i think maybe it should only be 

``` ruby
if env['HTTP_USER_AGENT'] =~ /^(Adobe|Shockwave) Flash/
  # ...
end
```
