### PR TITLE
do not overwrite cookie if it's already set

### DIFF
--- a/lib/flash_cookie_session/middleware.rb
+++ b/lib/flash_cookie_session/middleware.rb
@@ -23,7 +23,7 @@ module FlashCookieSession
 
         cookie_with_remember_token_and_session_key = [ the_remember_token, the_session_key ].compact.join('\;').freeze
 
-        env['HTTP_COOKIE'] = cookie_with_remember_token_and_session_key
+        env['HTTP_COOKIE'] = cookie_with_remember_token_and_session_key if env['HTTP_COOKIE'].blank?
         env['HTTP_ACCEPT'] = "#{req.params['_http_accept']}".freeze if req.params['_http_accept']
       end
 


### PR DESCRIPTION
In recent version of Firefox 28 with video flash based flowplayer session is correctly set when swf pulls file from server, so there is no need to set cookie and in that case flash_cookie_session just wipes session cookie which results in user being logged out from the site.

This change stops replacing cookie if it's already set, how ever a better solution would be to parse cookies and merge but that's another story.
