### PR TITLE
Add license to gemspec

### DIFF
--- a/flash_cookie_session.gemspec
+++ b/flash_cookie_session.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new do |s|
   s.homepage    = "http://rubygems.org/gems/flash_cookie_session"
   s.summary     = %q{Rails 3 cookie sessions can cooperate with Flash}
   s.description = %q{Useful for Flash-based file uploaders (SWFUpload, Uploadify, Plupload, etc)}
+  s.license     = 'MIT'
 
   s.rubyforge_project = "flash_cookie_session"
 


### PR DESCRIPTION
I was trying to determine the licenses for my dependencies. I found that the RubyGems API will return the license, but only if it is specified in your gemspec file.