### PR TITLE
Change middleware builder to not use deprecated style

### DIFF
--- a/lib/flash_cookie_session/railtie.rb
+++ b/lib/flash_cookie_session/railtie.rb
@@ -21,7 +21,7 @@ module FlashCookieSession
 
       Rails.application.middleware.insert_before(
         session_store,
-        "FlashCookieSession::Middleware",
+        FlashCookieSession::Middleware,
         session_key
       )
     end


### PR DESCRIPTION
The quoted style is deprecated now, so this just removes them.
